### PR TITLE
Add mealie with docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 This repo contains all the docker-compose apps that get deployed to my homeserver via portainer
 
 ## Apps
+- mealie

--- a/mealie/docker-compose.yml
+++ b/mealie/docker-compose.yml
@@ -4,19 +4,29 @@ services:
     image: hkotel/mealie:latest
     container_name: mealie
     environment:
-      - DB_HOST=postgres
-      - DB_PORT=5432
-      - DB_USER=mealie
-      - DB_NAME=mealie
-      - DB_PASS=${DB_PASS:?database password required}
-      - APP_ENV=production
-      - SECRET_KEY=${SECRET_KEY:?secret key required}
-      - BASE_URL=${BASE_URL:-http://localhost}
-      - ALLOWED_HOSTS=${ALLOWED_HOSTS:-*}
-      - DEBUG=${DEBUG:-False}
-      - TIMEZONE=${TIMEZONE:-UTC}
-      - DEFAULT_LANGUAGE=${DEFAULT_LANGUAGE:-en}
-      - DEFAULT_MEASUREMENT=${DEFAULT_MEASUREMENT:-metric}
+      ALLOW_SIGNUP: "false"
+      PUID: 1000
+      PGID: 1000
+      TZ: Europe/Berlin
+      MAX_WORKERS: 1
+      WEB_CONCURRENCY: 1
+      APP_ENV: production
+      SECRET_KEY: ${SECRET_KEY:?secret key required}
+      BASE_URL: ${BASE_URL:-http://localhost}
+      ALLOWED_HOSTS: ${ALLOWED_HOSTS:-*}
+      DEBUG: ${DEBUG:-False}
+       # Database Settings
+      DB_ENGINE: postgres
+      POSTGRES_USER: mealie
+      POSTGRES_PASSWORD: ${DB_PASS:?database password required}
+      POSTGRES_SERVER: postgres
+      POSTGRES_PORT: 5432
+      POSTGRES_DB: mealie
+      # OIDC Setup
+      OIDC_AUTH_ENABLED: true
+      OIDC_CONFIGURATION_URL: ${OIDC_CONFIGURATION_URL}
+      OIDC_CLIENT_ID: ${OIDC_CLIENT_ID}
+      OIDC_AUTO_REDIRECT: ${OIDC_AUTO_REDIRECT:-false}
     volumes:
       - mealie_data:/app/data
     networks:

--- a/mealie/docker-compose.yml
+++ b/mealie/docker-compose.yml
@@ -1,0 +1,32 @@
+version: "3.9"
+services:
+  mealie:
+    image: hkotel/mealie:latest
+    container_name: mealie
+    environment:
+      - DB_HOST=postgres
+      - DB_PORT=5432
+      - DB_USER=mealie
+      - DB_NAME=mealie
+      - DB_PASS=${DB_PASS:?database password required}
+      - APP_ENV=production
+      - SECRET_KEY=${SECRET_KEY:?secret key required}
+      - BASE_URL=${BASE_URL:-http://localhost}
+      - ALLOWED_HOSTS=${ALLOWED_HOSTS:-*}
+      - DEBUG=${DEBUG:-False}
+      - TIMEZONE=${TIMEZONE:-UTC}
+      - DEFAULT_LANGUAGE=${DEFAULT_LANGUAGE:-en}
+      - DEFAULT_MEASUREMENT=${DEFAULT_MEASUREMENT:-metric}
+    volumes:
+      - mealie_data:/app/data
+    networks:
+      - internal
+    restart: always
+
+volumes:
+  mealie_data:
+
+networks:
+  internal:
+    name: internal
+    external: true


### PR DESCRIPTION
Add a new folder for mealie with a `docker-compose.yml` file.

* Create a new `mealie` folder and add a `docker-compose.yml` file.
* Configure mealie to use `postgres` as the db host, `mealie` as the db user and db name, and use environment variables for the DB Password.
* Add default environment variables for mealie as described in the mealie documentation.
* Do not expose any ports and attach mealie to the `internal` network.
* Update `README.md` to include mealie in the list of apps.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BobcatProgrammer/homeserver?shareId=ce5766cc-5b57-488a-a8e8-3d4718c5d9ca).